### PR TITLE
Nested sub actions

### DIFF
--- a/r4/src/main/java/org/opencds/cqf/r4/providers/PlanDefinitionApplyProvider.java
+++ b/r4/src/main/java/org/opencds/cqf/r4/providers/PlanDefinitionApplyProvider.java
@@ -226,6 +226,9 @@ public class PlanDefinitionApplyProvider {
                         result.setId(UUID.randomUUID().toString());
                     }
 
+                    // Add the result to the overall CarePlan contained as well
+                    session.getCarePlanBuilder().buildContained(result);
+
                     session
                         .getRequestGroupBuilder()
                         .buildContained(result)

--- a/r4/src/main/java/org/opencds/cqf/r4/providers/PlanDefinitionApplyProvider.java
+++ b/r4/src/main/java/org/opencds/cqf/r4/providers/PlanDefinitionApplyProvider.java
@@ -134,17 +134,6 @@ public class PlanDefinitionApplyProvider {
         return session.getCarePlan();
     }
 
-    public List<Resource> getAllContainedResources(Resource resource) {
-        if (!(resource instanceof DomainResource)) {
-            return new ArrayList<>();
-        }
-        List<Resource> contained = ((DomainResource) resource).getContained();
-
-        return Stream
-            .concat(contained.stream(), contained.stream().flatMap(r -> getAllContainedResources(r).stream()))
-            .collect(Collectors.toList());
-    }
-
     private void resolveAction(Session session, PlanDefinition.PlanDefinitionActionComponent action) {
         // TODO - Apply input/output dataRequirements?
         if (meetsConditions(session, action)) {
@@ -225,9 +214,6 @@ public class PlanDefinitionApplyProvider {
                                 action.getDefinitionCanonicalType().getId());
                         result.setId(UUID.randomUUID().toString());
                     }
-
-                    // Add the result to the overall CarePlan contained as well
-                    session.getCarePlanBuilder().buildContained(result);
 
                     session
                         .getRequestGroupBuilder()

--- a/r4/src/main/java/org/opencds/cqf/r4/providers/PlanDefinitionApplyProvider.java
+++ b/r4/src/main/java/org/opencds/cqf/r4/providers/PlanDefinitionApplyProvider.java
@@ -119,11 +119,7 @@ public class PlanDefinitionApplyProvider {
 
     private CarePlan resolveActions(Session session) {
         for (PlanDefinition.PlanDefinitionActionComponent action : session.getPlanDefinition().getAction()) {
-            // TODO - Apply input/output dataRequirements?
-            if (meetsConditions(session, action)) {
-                resolveDefinition(session, action);
-                resolveDynamicActions(session, action);
-            }
+            resolveAction(session, action);
         }
 
         RequestGroup result = session.getRequestGroupBuilder().build();
@@ -136,6 +132,34 @@ public class PlanDefinitionApplyProvider {
             new CarePlanActivityBuilder().buildReference(new Reference("#" + result.getId())).build());
 
         return session.getCarePlan();
+    }
+
+    public List<Resource> getAllContainedResources(Resource resource) {
+        if (!(resource instanceof DomainResource)) {
+            return new ArrayList<>();
+        }
+        List<Resource> contained = ((DomainResource) resource).getContained();
+
+        return Stream
+            .concat(contained.stream(), contained.stream().flatMap(r -> getAllContainedResources(r).stream()))
+            .collect(Collectors.toList());
+    }
+
+    private void resolveAction(Session session, PlanDefinition.PlanDefinitionActionComponent action) {
+        // TODO - Apply input/output dataRequirements?
+        if (meetsConditions(session, action)) {
+            resolveDefinition(session, action);
+            resolveSubActions(session, action);
+            resolveDynamicActions(session, action);
+        }
+    }
+
+    private void resolveSubActions(Session session, PlanDefinition.PlanDefinitionActionComponent action) {
+        if (action.hasAction()) {
+            for (PlanDefinition.PlanDefinitionActionComponent subAction : action.getAction()) {
+               resolveAction(session, subAction); 
+            }
+        }
     }
 
     private void resolveDefinition(Session session, PlanDefinition.PlanDefinitionActionComponent action) {


### PR DESCRIPTION
Support nested sub actions in the $apply operation by resolving all subactions of actions. Marked as WIP since verifying with Reece this did not break his RequestGroup changes. Had to make a small modification to RequestGroup to correctly add the contained resources. 
See folder below with a sample JSON Bundle
[Sub-Actions.zip](https://github.com/mcode/cqf-ruler/files/5246349/Sub-Actions.zip)

To Test: 
1. POST the `example-sub-actions.json` Bundle to the cqf-ruler
2. Apply the `pd-example-subactions` PlanDefinition: http://localhost:8080/cqf-ruler-r4/fhir/PlanDefinition/pd-example-subactions/$apply?_patient=Patient/example
3. Verify the CarePlan (Medication 1 & 2 are in CarePlan but not 3). The PlanDefinition is structured as follows
          Action 1: applicability true              
| - Sub-Action: Medication 1 -- applicability true
| - Sub-Action: Medication 3 -- applicability false
          Action 2: Medication 2 -- applicability true
