### PR TITLE
Fix Nested Contained Resources

### DIFF
--- a/r4/src/main/java/org/opencds/cqf/r4/helpers/ContainedHelper.java
+++ b/r4/src/main/java/org/opencds/cqf/r4/helpers/ContainedHelper.java
@@ -63,7 +63,7 @@ public class ContainedHelper {
   }
 
   /**
-   * @see ContainedHelper#streamContainedResourcesInContainedResources(Resource)
+   * @see ContainedHelper#getContainedResourcesInContainedResources(Resource)
    */
   private static Stream<Resource> streamContainedResourcesInContainedResources(Resource resource) {
     if (!(resource instanceof DomainResource)) {
@@ -76,7 +76,7 @@ public class ContainedHelper {
   }
 
   /**
-   * @see ContainedHelper#streamAllContainedResources(Resource) 
+   * @see ContainedHelper#getAllContainedResources(Resource)
    */
   private static Stream<Resource> streamAllContainedResources(Resource resource) {
     if (!(resource instanceof DomainResource)) {

--- a/r4/src/main/java/org/opencds/cqf/r4/helpers/ContainedHelper.java
+++ b/r4/src/main/java/org/opencds/cqf/r4/helpers/ContainedHelper.java
@@ -1,0 +1,58 @@
+package org.opencds.cqf.r4.helpers;
+
+import org.hl7.fhir.r4.model.DomainResource;
+import org.hl7.fhir.r4.model.Resource;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+public class ContainedHelper {
+
+  // > Contained resources SHALL NOT contain additional contained resources.
+  // https://www.hl7.org/fhir/references.html#contained
+  public static DomainResource liftContainedResourcesToParent(DomainResource resource) {
+    getContainedResourcesInContainedResources(resource)
+        .forEach(resource::addContained);   // add them to the parent
+
+    return resource;  // Return the resource to allow for method chaining
+  }
+
+  private static List<Resource> getContainedResourcesInContainedResources(Resource resource) {
+    if (!(resource instanceof DomainResource)) {
+      return new ArrayList<>();
+    }
+    return streamContainedResourcesInContainedResources(resource).collect(Collectors.toList());
+  }
+
+  public static List<Resource> getAllContainedResources(Resource resource) {
+    if (!(resource instanceof DomainResource)) {
+      return new ArrayList<>();
+    }
+    return streamAllContainedResources(resource).collect(Collectors.toList());
+  }
+
+  private static Stream<Resource> streamContainedResourcesInContainedResources(Resource resource) {
+    if (!(resource instanceof DomainResource)) {
+      return Stream.empty();
+    }
+    return ((DomainResource) resource)
+        .getContained() // We don't need to re-add any resources that are already on the parent.
+        .stream()
+        .flatMap(ContainedHelper::streamAllContainedResources);  // Get the resources contained
+  }
+
+  private static Stream<Resource> streamAllContainedResources(Resource resource) {
+    if (!(resource instanceof DomainResource)) {
+      return Stream.empty();
+    }
+    List<Resource> contained = ((DomainResource) resource).getContained();
+
+    return Stream
+        .concat(contained.stream(),
+            contained
+                .stream()
+                .flatMap(ContainedHelper::streamAllContainedResources));
+  }
+}

--- a/r4/src/main/java/org/opencds/cqf/r4/helpers/ContainedHelper.java
+++ b/r4/src/main/java/org/opencds/cqf/r4/helpers/ContainedHelper.java
@@ -8,10 +8,27 @@ import java.util.List;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
+/**
+ * This class consists exclusively of static methods that assist with managing contained FHIR
+ * Resources.
+ *
+ * The FHIR specification does not allow contained resources to contain additional resources:
+ * > Contained resources SHALL NOT contain additional contained resources.
+ * https://www.hl7.org/fhir/references.html#contained
+ *
+ * When returning a resource from an annotated method that responds to an incoming request any
+ * resources contained in another resource will be removed.  `liftContainedResourcesToParent` in
+ * this class will move all contained resources to the parent so they are present in responses
+ * to clients.
+ */
 public class ContainedHelper {
 
-  // > Contained resources SHALL NOT contain additional contained resources.
-  // https://www.hl7.org/fhir/references.html#contained
+  /**
+   * Adds all contained resources in resources contained on the parent to the parent.
+   *
+   * @param resource the parent resource where contained resources should be
+   * @return the modified parent resource
+   */
   public static DomainResource liftContainedResourcesToParent(DomainResource resource) {
     getContainedResourcesInContainedResources(resource)
         .forEach(resource::addContained);   // add them to the parent
@@ -19,6 +36,12 @@ public class ContainedHelper {
     return resource;  // Return the resource to allow for method chaining
   }
 
+  /**
+   * Returns all contained resources that are not already directly present on the parent resource.
+   *
+   * @param resource the parent resource
+   * @return list of the contained resources
+   */
   private static List<Resource> getContainedResourcesInContainedResources(Resource resource) {
     if (!(resource instanceof DomainResource)) {
       return new ArrayList<>();
@@ -26,6 +49,12 @@ public class ContainedHelper {
     return streamContainedResourcesInContainedResources(resource).collect(Collectors.toList());
   }
 
+  /**
+   * Returns all contained resources, including resources directly contained on the parent and
+   * resources contained on any other contained resource
+   * @param resource the parent resource
+   * @return list of all contained resources
+   */
   public static List<Resource> getAllContainedResources(Resource resource) {
     if (!(resource instanceof DomainResource)) {
       return new ArrayList<>();
@@ -33,6 +62,9 @@ public class ContainedHelper {
     return streamAllContainedResources(resource).collect(Collectors.toList());
   }
 
+  /**
+   * @see ContainedHelper#streamContainedResourcesInContainedResources(Resource)
+   */
   private static Stream<Resource> streamContainedResourcesInContainedResources(Resource resource) {
     if (!(resource instanceof DomainResource)) {
       return Stream.empty();
@@ -43,6 +75,9 @@ public class ContainedHelper {
         .flatMap(ContainedHelper::streamAllContainedResources);  // Get the resources contained
   }
 
+  /**
+   * @see ContainedHelper#streamAllContainedResources(Resource) 
+   */
   private static Stream<Resource> streamAllContainedResources(Resource resource) {
     if (!(resource instanceof DomainResource)) {
       return Stream.empty();

--- a/r4/src/main/java/org/opencds/cqf/r4/providers/PlanDefinitionApplyProvider.java
+++ b/r4/src/main/java/org/opencds/cqf/r4/providers/PlanDefinitionApplyProvider.java
@@ -5,8 +5,6 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.UUID;
-import java.util.stream.Collectors;
-import java.util.stream.Stream;
 
 import org.hl7.fhir.exceptions.FHIRException;
 import org.hl7.fhir.r4.model.ActivityDefinition;

--- a/r4/src/main/java/org/opencds/cqf/r4/providers/PlanDefinitionApplyProvider.java
+++ b/r4/src/main/java/org/opencds/cqf/r4/providers/PlanDefinitionApplyProvider.java
@@ -37,6 +37,7 @@ import org.opencds.cqf.r4.builders.RelatedArtifactBuilder;
 import org.opencds.cqf.r4.builders.RequestGroupActionBuilder;
 import org.opencds.cqf.r4.builders.RequestGroupBuilder;
 import org.opencds.cqf.r4.helpers.CanonicalHelper;
+import org.opencds.cqf.r4.helpers.ContainedHelper;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -115,7 +116,7 @@ public class PlanDefinitionApplyProvider {
         Session session = new Session(planDefinition, builder, patientId, encounterId, practitionerId, organizationId,
                 userType, userLanguage, userTaskContext, setting, settingContext, requestGroupBuilder);
 
-        return resolveActions(session);
+        return (CarePlan) ContainedHelper.liftContainedResourcesToParent(resolveActions(session));
     }
 
     private CarePlan resolveActions(Session session) {
@@ -139,17 +140,6 @@ public class PlanDefinitionApplyProvider {
         return session.getCarePlan();
     }
 
-    public List<Resource> getAllContainedResources(Resource resource) {
-        if (!(resource instanceof DomainResource)) {
-            return new ArrayList<>();
-        }
-        List<Resource> contained = ((DomainResource) resource).getContained();
-
-        return Stream
-            .concat(contained.stream(), contained.stream().flatMap(r -> getAllContainedResources(r).stream()))
-            .collect(Collectors.toList());
-    }
-
     private void resolveDefinition(Session session, PlanDefinition.PlanDefinitionActionComponent action) {
         if (action.hasDefinition()) {
             logger.debug("Resolving definition " + action.getDefinitionCanonicalType().getValue());
@@ -169,25 +159,13 @@ public class PlanDefinitionApplyProvider {
                             session.getSetting(),
                             session.getSettingContext());
 
-                    // Pull contained resources up to the CarePlan
-                    // > Contained resources SHALL NOT contain additional contained resources.
-                    // https://www.hl7.org/fhir/references.html#contained
-                    getAllContainedResources(plan)
-                        .forEach(r ->
-                        session
-                            .getCarePlanBuilder()
-                            .buildContained(r)
-                    );
-
                     if (plan.getId() == null) {
                         plan.setId(UUID.randomUUID().toString());
                     }
 
-                    // Add the overall carePlan to the contained as well
-                    session.getCarePlanBuilder().buildContained(plan);
-
                     // Add an action to the request group which points to this CarePlan
                     session.getRequestGroupBuilder()
+                        .buildContained(plan)
                         .addAction(new RequestGroupActionBuilder()
                             .buildResource(new Reference("#" + plan.getId()))
                             .build()


### PR DESCRIPTION
@blangley28 pointed out an issue with how contained resources were lifted to the parent resource where only resources in nested PlanDefinitions were lifted correctly.

There is a pretty simple fix ([this this one line commit](https://github.com/mcode/cqf-ruler/commit/faca0fc67c30dc64dfa567d4235e0ff2a85b077f) from @blangley28)  for this because ultimately I just forgot to add the resulting request to the CarePlan in addition to where it was already added to the RequestGroup.  Doing this in multiple places in this method, which has a few code paths, is error prone.

While looking at this and making sure the problem was fixed I moved these methods for helping manage the contained resources into their own class and changed how the `$apply` operation uses it so that its just the last step before responding.

If we want to leave the logic as is and take @blangley28's solution I'm good with that too, but this felt cleaner and easier to reason with.